### PR TITLE
Added Python 3.5, Django 1.9-10, and DRF 3.3-4 tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,55 @@
 language: python
-
+cache: pip
 sudo: false
 
+python:
+  - 3.5
+
 env:
+  - TOX_ENV=py35-django-110-drf-33
+  - TOX_ENV=py35-django-110-drf-34
+  - TOX_ENV=py35-django-19-drf-31
+  - TOX_ENV=py35-django-19-drf-32
+  - TOX_ENV=py35-django-19-drf-33
+  - TOX_ENV=py35-django-19-drf-34
+  - TOX_ENV=py35-django-18-drf-30
+  - TOX_ENV=py35-django-18-drf-31
+  - TOX_ENV=py35-django-18-drf-32
+  - TOX_ENV=py35-django-18-drf-33
+  - TOX_ENV=py35-django-18-drf-34
   - TOX_ENV=py34-flake8
   - TOX_ENV=py34-docs
-  - TOX_ENV=py27-django1.6-drf3.0
-  - TOX_ENV=py27-django1.6-drf3.1
-  - TOX_ENV=py27-django1.6-drf3.2
-  - TOX_ENV=py27-django1.7-drf3.0
-  - TOX_ENV=py27-django1.7-drf3.1
-  - TOX_ENV=py27-django1.7-drf3.2
-  - TOX_ENV=py27-django1.8-drf3.0
-  - TOX_ENV=py27-django1.8-drf3.1
-  - TOX_ENV=py27-django1.8-drf3.2
-  - TOX_ENV=py33-django1.6-drf3.0
-  - TOX_ENV=py33-django1.6-drf3.1
-  - TOX_ENV=py33-django1.6-drf3.2
-  - TOX_ENV=py33-django1.7-drf3.0
-  - TOX_ENV=py33-django1.7-drf3.1
-  - TOX_ENV=py33-django1.7-drf3.2
-  - TOX_ENV=py33-django1.8-drf3.0
-  - TOX_ENV=py33-django1.8-drf3.1
-  - TOX_ENV=py33-django1.8-drf3.2
-  - TOX_ENV=py34-django1.6-drf3.0
-  - TOX_ENV=py34-django1.6-drf3.1
-  - TOX_ENV=py34-django1.6-drf3.2
-  - TOX_ENV=py34-django1.7-drf3.0
-  - TOX_ENV=py34-django1.7-drf3.1
-  - TOX_ENV=py34-django1.7-drf3.2
-  - TOX_ENV=py34-django1.8-drf3.0
-  - TOX_ENV=py34-django1.8-drf3.1
-  - TOX_ENV=py34-django1.8-drf3.2
+  - TOX_ENV=py34-django-110-drf-33
+  - TOX_ENV=py34-django-110-drf-34
+  - TOX_ENV=py34-django-19-drf-31
+  - TOX_ENV=py34-django-19-drf-32
+  - TOX_ENV=py34-django-19-drf-33
+  - TOX_ENV=py34-django-19-drf-34
+  - TOX_ENV=py34-django-18-drf-30
+  - TOX_ENV=py34-django-18-drf-31
+  - TOX_ENV=py34-django-18-drf-32
+  - TOX_ENV=py34-django-18-drf-33
+  - TOX_ENV=py34-django-18-drf-34
+  - TOX_ENV=py33-django-18-drf-30
+  - TOX_ENV=py33-django-18-drf-31
+  - TOX_ENV=py33-django-18-drf-32
+  - TOX_ENV=py33-django-18-drf-33
+  - TOX_ENV=py33-django-18-drf-34
+  - TOX_ENV=py27-django-110-drf-33
+  - TOX_ENV=py27-django-19-drf-31
+  - TOX_ENV=py27-django-19-drf-32
+  - TOX_ENV=py27-django-19-drf-33
+  - TOX_ENV=py27-django-18-drf-30
+  - TOX_ENV=py27-django-18-drf-31
+  - TOX_ENV=py27-django-18-drf-32
+  - TOX_ENV=py27-django-18-drf-33
+  - TOX_ENV=py27-django-17-drf-30
+  - TOX_ENV=py27-django-17-drf-31
+  - TOX_ENV=py27-django-17-drf-32
+  - TOX_ENV=py27-django-17-drf-33
+  - TOX_ENV=py27-django-16-drf-30
+  - TOX_ENV=py27-django-16-drf-31
+  - TOX_ENV=py27-django-16-drf-32
 
 install:
   - pip install tox

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ This library aims to make maintenance of resource versions simple and intuitive 
 Requirements
 ------------
 
--  Python (2.7, 3.3, 3.4)
--  Django (1.6, 1.7, 1.8)
--  Django REST Framework (2.4, 3.0, 3.1)
+-  Python (2.7, 3.3, 3.4, 3.5)
+-  Django (1.6, 1.7, 1.8, 1.9, 1.10)
+-  Django REST Framework (3.0, 3.1, 3.2, 3.3, 3.4)
 
 Installation
 ------------
@@ -125,7 +125,7 @@ In the second example, the `.backwards()` method would remove the field that is 
 
 #### Uniform vs. Per-Endpoint Versioning
 
-There are two schools of thought around versioning of resources within a REST API. 
+There are two schools of thought around versioning of resources within a REST API.
 Uniform API versioning schemes increment the version of the entire API at once whenever one endpoint introduces an incompatible change.
 In contrast, Per-Endpoint API versioning allows demands that a client know the version number of each resource with which they interact.
 
@@ -294,6 +294,14 @@ against all supported versions of Python and Django. Install tox globally, and t
 ```bash
 $ tox
 ```
+
+It is best to specify an environment or this will take at least 1 hour (if you're lucky). It is recommended to test locally on the latest versions of Django and Django REST Framework and setup Travis for your fork before making a pull request to make sure all tests pass.
+
+```bash
+$ tox -e {ENVIRONMENT}
+```
+
+See `tox.ini` for all tested environments.
 
 ### Documentation
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,18 @@
 [tox]
 envlist =
-    py34-{flake8,docs},
-    {py27,py33,py34}-django{1.6,1.7,1.8}-drf{3.0,3.1,3.2}
+    py35-django-110-drf-{33,34}
+    py35-django-19-drf-{31,32,33,34}
+    py35-django-18-drf-{30,31,32,33,34}
+    py34-{flake8,docs}
+    py34-django-110-drf-{33,34}
+    py34-django-19-drf-{31,32,33,34}
+    py34-django-18-drf-{30,31,32,33,34}
+    py33-django-18-drf-{30,31,32,33,34}
+    py27-django-110-drf-{33}
+    py27-django-19-drf-{31,32,33}
+    py27-django-18-drf-{30,31,32,33}
+    py27-django-17-drf-{30,31,32,33}
+    py27-django-16-drf-{30,31,32}
 
 [testenv]
 commands = ./runtests.py --fast
@@ -9,12 +20,17 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONPATH = {toxinidir}:{toxinidir}/django-rest-framework-version-transforms
 deps =
-    django1.6: Django>=1.6, <1.7
-    django1.7: Django>=1.7, <1.8
-    django1.8: Django>=1.8, <1.9
-    drf3.0: djangorestframework>=3.0, <3.1
-    drf3.1: djangorestframework>=3.1, <3.2
-    drf3.2: djangorestframework>=3.2, <3.3
+    django-16: Django>=1.6, <1.7
+    django-17: Django>=1.7, <1.8
+    django-18: Django>=1.8, <1.9
+    django-19: Django>=1.9, <1.10
+    django-110: Django>=1.10, <1.11
+    drf-30: djangorestframework>=3.0, <3.1
+    drf-31: djangorestframework>=3.1, <3.2
+    drf-32: djangorestframework>=3.2, <3.3
+    drf-33: djangorestframework>=3.3, <3.4
+    drf-34: djangorestframework>=3.4, <3.5
+    drf-35: djangorestframework>=3.5, <3.6
     pytest-django>=2.8, <2.9
     ipdb>=0.8
     mock>=1.3.0, <1.4


### PR DESCRIPTION
I've added the environments for Python 3.5, Django 1.9-10, and Django REST Framework 3.3-4. I've used the release notes of DRF to know what versions were supported.

I've updated the README to reflect this and added a little note on how to preferably test imo as I doubt someone can run all of these tests on their machine. Even with `detox` they'll probably fry their system trying to run 44 tests at once.

I've added the following to `.travis.yml`:
```yaml
python:
  - 3.5
```
Because Travis somehow does not have the Python 3.5 binary available if not specified. The downside to this is that all tests appear to run Python 3.5. I guess you have to take it up with Travis for that. See travis-ci/travis-ci#5993 and travis-ci/travis-ci#4794.

I've also changed the order of the tox environments from high to low as I think it's more important to see the latest version tests first. I doubt anyone wants to wait 10 minutes to see Python 3.5 tests.